### PR TITLE
feat(kiota): Add support for `file:` download URLs

### DIFF
--- a/kiota-gen-example/package-lock.json
+++ b/kiota-gen-example/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "1.0.0-preview.32",
-        "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.31",
-        "@microsoft/kiota-serialization-form": "1.0.0-preview.21",
-        "@microsoft/kiota-serialization-json": "1.0.0-preview.32",
-        "@microsoft/kiota-serialization-multipart": "1.0.0-preview.11",
-        "@microsoft/kiota-serialization-text": "1.0.0-preview.29"
+        "@microsoft/kiota-abstractions": "1.0.0-preview.75",
+        "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.75",
+        "@microsoft/kiota-serialization-form": "1.0.0-preview.75",
+        "@microsoft/kiota-serialization-json": "1.0.0-preview.75",
+        "@microsoft/kiota-serialization-multipart": "1.0.0-preview.75",
+        "@microsoft/kiota-serialization-text": "1.0.0-preview.75"
       },
       "devDependencies": {
         "@kiota-community/kiota-gen": "file:../kiota-gen",
@@ -28,7 +28,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "decompress": "4.2.1",
-        "follow-redirects": "1.15.3",
+        "follow-redirects": "1.15.9",
         "shelljs": "0.8.5"
       },
       "bin": {
@@ -57,68 +57,61 @@
       "link": true
     },
     "node_modules/@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.32.tgz",
-      "integrity": "sha512-F7V+BF2I7lM1RHO4b0Rq1K2KG4zhrG4ZIfFiLpXeEd53LBGY5taGelQxoMrslq+AJBprFrvWxCBoo8+GbXr0+w==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.75.tgz",
+      "integrity": "sha512-4AHGZbBK0TF3Juoqv4nm/hatY9gmxMliEI6LBnJ0NX/bnrbkXYWYFqd77UNLqunum+UO9Z5TXkZ61iH/SfnJOw==",
       "dependencies": {
-        "@opentelemetry/api": "^1.2.0",
-        "@std-uritemplate/std-uritemplate": "^0.0.46",
-        "guid-typescript": "^1.0.9",
-        "tinyduration": "^3.2.2",
-        "tslib": "^2.3.1",
-        "uuid": "^9.0.0"
+        "@opentelemetry/api": "^1.7.0",
+        "@std-uritemplate/std-uritemplate": "^1.0.1",
+        "tinyduration": "^3.3.0",
+        "tslib": "^2.6.2",
+        "uuid": "^11.0.2"
       }
     },
     "node_modules/@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.31",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.31.tgz",
-      "integrity": "sha512-ZHDgadeUcMXR179GRKnq9qirminT6//EaBIJ0G9m9wBwDh4OCEYtFhoJS7K0hd+QukjyAz6deMS0tntw+w6eLQ==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.75.tgz",
+      "integrity": "sha512-JDLNjZSV0V05by63BOg7SY67YHzVbSeFnWsEViCO4iYMf0rUEVI4Il02YzMISQr6NE2ewiUmHhyyzBmCzZbjiA==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "@opentelemetry/api": "^1.2.0",
-        "guid-typescript": "^1.0.9",
-        "node-fetch": "^2.6.5",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "@opentelemetry/api": "^1.7.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.21",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.21.tgz",
-      "integrity": "sha512-92xZpx2Kn3K1aP++wK1kxU6Z9+N4AlSV3/rdW5BvIIf0yzyYCbHtMQV7e5nkCkDtm4gj+sa3FW8mLU3MWSXq/A==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.75.tgz",
+      "integrity": "sha512-6ePhlseALvXClmMbckPMSQkdxLDTdpKqb1zXjcNmyizBIUWOXIJOshS0vto8CVFn24hXej4XPPG5zbpds77caw==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.32.tgz",
-      "integrity": "sha512-xl/DVsdT9O4EfRs+a6xa/SRSFcfLgG7+XP3WvZM4c404h4aqAgJxgsdDf9ETWQ1uQsiaOHMC5DDcye6y0/iw8Q==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.75.tgz",
+      "integrity": "sha512-Kew92emgw6DEHnkIdxlPzwc7Tr4yyD0b4BlsjSRJ/si72Z6wLAP/WOe7SpBYuKhFpkxCbpoSG6/SAZLqaFcw3A==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.11.tgz",
-      "integrity": "sha512-u5T9RdoQrCsIZjo+bFh2X/g5+tOMT70xPvaoCrTv7SLCiOn2VI20cI5dhq3Y7xyadWYOnW1C/27tRiY2uzyjIw==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.75.tgz",
+      "integrity": "sha512-xdt1gSnZiDbOCE4v68s3KiUo7Nt4cRs5J8dvZUSjMlJCecYGt1xxL9FVY6ZLW8JxwAQANEULgSaS2s4ajaWxdA==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.29.tgz",
-      "integrity": "sha512-Bqltd/Z+bv8IXBGw3gGR7q3YY/0SVaJxv23PTKv0/FeXmAzOUM8szIz33bqgTD5lHR7gb8wHMXQ6M9IhCu21eg==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.75.tgz",
+      "integrity": "sha512-1FE2Jj32HSVFTaH9jWnoGfoVbPy+zxBeos+IJY5kyb9Gq/v3VMfgOgbjLQZs2ZtT8u/oDc8bTIIns2Yx9/CFIQ==",
       "dependencies": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -140,9 +133,9 @@
       }
     },
     "node_modules/@std-uritemplate/std-uritemplate": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-0.0.46.tgz",
-      "integrity": "sha512-GAJuWR04lNIdtJZfjVh6oH+fvjbXR30uim1SAPGmoUrztFQUeU0JbnR+Va1FKhEd/bdZae4tPlrYeKsJU6pE8A=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-1.0.6.tgz",
+      "integrity": "sha512-+S9kAqK60nZZyvhvesoXut6NB9qB80VTpNsdiOeHmE0FAMOEsJy9/dakDL3xMp3kNRFvviw0mX9WPSuasvSxCQ=="
     },
     "node_modules/ansi-regex": {
       "version": "6.0.1",
@@ -234,11 +227,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -288,25 +276,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
       }
     },
     "node_modules/path-key": {
@@ -532,40 +501,21 @@
       "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.3.0.tgz",
       "integrity": "sha512-sLR0iVUnnnyGEX/a3jhTA0QMK7UvakBqQJFLiibiuEYL6U1L85W+qApTZj6DcL1uoWQntYuL0gExoe9NU5B3PA=="
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/which": {
@@ -694,73 +644,66 @@
       "version": "file:../kiota-gen",
       "requires": {
         "decompress": "4.2.1",
-        "follow-redirects": "1.15.3",
+        "follow-redirects": "1.15.9",
         "shelljs": "0.8.5"
       }
     },
     "@microsoft/kiota-abstractions": {
-      "version": "1.0.0-preview.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.32.tgz",
-      "integrity": "sha512-F7V+BF2I7lM1RHO4b0Rq1K2KG4zhrG4ZIfFiLpXeEd53LBGY5taGelQxoMrslq+AJBprFrvWxCBoo8+GbXr0+w==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-abstractions/-/kiota-abstractions-1.0.0-preview.75.tgz",
+      "integrity": "sha512-4AHGZbBK0TF3Juoqv4nm/hatY9gmxMliEI6LBnJ0NX/bnrbkXYWYFqd77UNLqunum+UO9Z5TXkZ61iH/SfnJOw==",
       "requires": {
-        "@opentelemetry/api": "^1.2.0",
-        "@std-uritemplate/std-uritemplate": "^0.0.46",
-        "guid-typescript": "^1.0.9",
-        "tinyduration": "^3.2.2",
-        "tslib": "^2.3.1",
-        "uuid": "^9.0.0"
+        "@opentelemetry/api": "^1.7.0",
+        "@std-uritemplate/std-uritemplate": "^1.0.1",
+        "tinyduration": "^3.3.0",
+        "tslib": "^2.6.2",
+        "uuid": "^11.0.2"
       }
     },
     "@microsoft/kiota-http-fetchlibrary": {
-      "version": "1.0.0-preview.31",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.31.tgz",
-      "integrity": "sha512-ZHDgadeUcMXR179GRKnq9qirminT6//EaBIJ0G9m9wBwDh4OCEYtFhoJS7K0hd+QukjyAz6deMS0tntw+w6eLQ==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-http-fetchlibrary/-/kiota-http-fetchlibrary-1.0.0-preview.75.tgz",
+      "integrity": "sha512-JDLNjZSV0V05by63BOg7SY67YHzVbSeFnWsEViCO4iYMf0rUEVI4Il02YzMISQr6NE2ewiUmHhyyzBmCzZbjiA==",
       "requires": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "@opentelemetry/api": "^1.2.0",
-        "guid-typescript": "^1.0.9",
-        "node-fetch": "^2.6.5",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "@opentelemetry/api": "^1.7.0",
+        "tslib": "^2.6.2"
       }
     },
     "@microsoft/kiota-serialization-form": {
-      "version": "1.0.0-preview.21",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.21.tgz",
-      "integrity": "sha512-92xZpx2Kn3K1aP++wK1kxU6Z9+N4AlSV3/rdW5BvIIf0yzyYCbHtMQV7e5nkCkDtm4gj+sa3FW8mLU3MWSXq/A==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-form/-/kiota-serialization-form-1.0.0-preview.75.tgz",
+      "integrity": "sha512-6ePhlseALvXClmMbckPMSQkdxLDTdpKqb1zXjcNmyizBIUWOXIJOshS0vto8CVFn24hXej4XPPG5zbpds77caw==",
       "requires": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "@microsoft/kiota-serialization-json": {
-      "version": "1.0.0-preview.32",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.32.tgz",
-      "integrity": "sha512-xl/DVsdT9O4EfRs+a6xa/SRSFcfLgG7+XP3WvZM4c404h4aqAgJxgsdDf9ETWQ1uQsiaOHMC5DDcye6y0/iw8Q==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-json/-/kiota-serialization-json-1.0.0-preview.75.tgz",
+      "integrity": "sha512-Kew92emgw6DEHnkIdxlPzwc7Tr4yyD0b4BlsjSRJ/si72Z6wLAP/WOe7SpBYuKhFpkxCbpoSG6/SAZLqaFcw3A==",
       "requires": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "@microsoft/kiota-serialization-multipart": {
-      "version": "1.0.0-preview.11",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.11.tgz",
-      "integrity": "sha512-u5T9RdoQrCsIZjo+bFh2X/g5+tOMT70xPvaoCrTv7SLCiOn2VI20cI5dhq3Y7xyadWYOnW1C/27tRiY2uzyjIw==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-multipart/-/kiota-serialization-multipart-1.0.0-preview.75.tgz",
+      "integrity": "sha512-xdt1gSnZiDbOCE4v68s3KiUo7Nt4cRs5J8dvZUSjMlJCecYGt1xxL9FVY6ZLW8JxwAQANEULgSaS2s4ajaWxdA==",
       "requires": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "@microsoft/kiota-serialization-text": {
-      "version": "1.0.0-preview.29",
-      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.29.tgz",
-      "integrity": "sha512-Bqltd/Z+bv8IXBGw3gGR7q3YY/0SVaJxv23PTKv0/FeXmAzOUM8szIz33bqgTD5lHR7gb8wHMXQ6M9IhCu21eg==",
+      "version": "1.0.0-preview.75",
+      "resolved": "https://registry.npmjs.org/@microsoft/kiota-serialization-text/-/kiota-serialization-text-1.0.0-preview.75.tgz",
+      "integrity": "sha512-1FE2Jj32HSVFTaH9jWnoGfoVbPy+zxBeos+IJY5kyb9Gq/v3VMfgOgbjLQZs2ZtT8u/oDc8bTIIns2Yx9/CFIQ==",
       "requires": {
-        "@microsoft/kiota-abstractions": "^1.0.0-preview.32",
-        "guid-typescript": "^1.0.9",
-        "tslib": "^2.3.1"
+        "@microsoft/kiota-abstractions": "^1.0.0-preview.75",
+        "tslib": "^2.6.2"
       }
     },
     "@opentelemetry/api": {
@@ -776,9 +719,9 @@
       "optional": true
     },
     "@std-uritemplate/std-uritemplate": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-0.0.46.tgz",
-      "integrity": "sha512-GAJuWR04lNIdtJZfjVh6oH+fvjbXR30uim1SAPGmoUrztFQUeU0JbnR+Va1FKhEd/bdZae4tPlrYeKsJU6pE8A=="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@std-uritemplate/std-uritemplate/-/std-uritemplate-1.0.6.tgz",
+      "integrity": "sha512-+S9kAqK60nZZyvhvesoXut6NB9qB80VTpNsdiOeHmE0FAMOEsJy9/dakDL3xMp3kNRFvviw0mX9WPSuasvSxCQ=="
     },
     "ansi-regex": {
       "version": "6.0.1",
@@ -846,11 +789,6 @@
         "signal-exit": "^4.0.1"
       }
     },
-    "guid-typescript": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
-      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="
-    },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -884,14 +822,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
       "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
     },
     "path-key": {
       "version": "3.1.1",
@@ -1048,34 +978,15 @@
       "resolved": "https://registry.npmjs.org/tinyduration/-/tinyduration-3.3.0.tgz",
       "integrity": "sha512-sLR0iVUnnnyGEX/a3jhTA0QMK7UvakBqQJFLiibiuEYL6U1L85W+qApTZj6DcL1uoWQntYuL0gExoe9NU5B3PA=="
     },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
     "tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.3.tgz",
+      "integrity": "sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg=="
     },
     "which": {
       "version": "2.0.2",

--- a/kiota-gen-example/package.json
+++ b/kiota-gen-example/package.json
@@ -27,11 +27,11 @@
     "rimraf": "5.0.5"
   },
   "dependencies": {
-    "@microsoft/kiota-abstractions": "1.0.0-preview.32",
-    "@microsoft/kiota-serialization-json": "1.0.0-preview.32",
-    "@microsoft/kiota-serialization-text": "1.0.0-preview.29",
-    "@microsoft/kiota-serialization-multipart": "1.0.0-preview.11",
-    "@microsoft/kiota-serialization-form": "1.0.0-preview.21",
-    "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.31"
+    "@microsoft/kiota-abstractions": "1.0.0-preview.75",
+    "@microsoft/kiota-serialization-json": "1.0.0-preview.75",
+    "@microsoft/kiota-serialization-text": "1.0.0-preview.75",
+    "@microsoft/kiota-serialization-multipart": "1.0.0-preview.75",
+    "@microsoft/kiota-serialization-form": "1.0.0-preview.75",
+    "@microsoft/kiota-http-fetchlibrary": "1.0.0-preview.75"
   }
 }

--- a/kiota-gen/package-lock.json
+++ b/kiota-gen/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "decompress": "4.2.1",
-        "follow-redirects": "1.15.3",
+        "follow-redirects": "1.15.9",
         "shelljs": "0.8.5"
       },
       "bin": {
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -836,9 +836,9 @@
       "integrity": "sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ=="
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "fs-constants": {
       "version": "1.0.0",

--- a/kiota-gen/package.json
+++ b/kiota-gen/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://github.com/kiota-community/kiota-js-extra#readme",
   "dependencies": {
     "shelljs": "0.8.5",
-    "follow-redirects": "1.15.3",
+    "follow-redirects": "1.15.9",
     "decompress": "4.2.1"
   }
 }


### PR DESCRIPTION
This PR adds support for URLs of the form `file:///tmp/examples/` as the value for `KIOTA_DOWNLOAD_URL`.  If the URL provided is a `file:` URL, the tool will now use `copyFile` rather than try to use `https.get` (which fails).