### PR TITLE
Migrate npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/kiota-gen.release.yaml
+++ b/.github/workflows/kiota-gen.release.yaml
@@ -10,18 +10,18 @@ jobs:
   release:
     name: Release Kiota Gen
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 24
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Check Node Version
-        run: node --version
-
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Build Project
         run: |
@@ -35,8 +35,8 @@ jobs:
           npm version ${{ github.event.inputs.release-version }}
 
       - name: Publish to npmjs.com
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd kiota-gen/dist
-          npm publish --access public
+          npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ''


### PR DESCRIPTION
Following up the failed release:
https://github.com/kiota-community/kiota-js-extra/actions/runs/29341503792

## Summary
- Classic npm tokens were permanently revoked on Dec 9, 2025, breaking the release workflow
- Replace `NPM_TOKEN`-based auth with OIDC trusted publishing (no secrets needed)
- Upgrade actions to `@v4` and Node to 22

## Before merging

@EricWittmann I think you have the power to configure the trusted publisher on npmjs.com for `@kiota-community/kiota-gen`:
1. Go to https://www.npmjs.com/package/@kiota-community/kiota-gen/access
2. Add a GitHub Actions trusted publisher:
   - **Organization**: `kiota-community`
   - **Repository**: `kiota-js-extra`
   - **Workflow filename**: `kiota-gen.release.yaml`

Docs: https://docs.npmjs.com/trusted-publishers/